### PR TITLE
Actually cycle through GPU IDs in find_suitable_gpu

### DIFF
--- a/src/drm_setup.c
+++ b/src/drm_setup.c
@@ -22,6 +22,7 @@ struct etna_gpu *find_suitable_gpu(struct etna_device *dev)
             return gpu;
         }
         etna_gpu_del(gpu);
+        ++core_id;
     }
 }
 


### PR DESCRIPTION
In the current version, if the first returned GPU does not have the
desired features, we are stuck in an endless loop, since we always
retry with the exact same ID.

This patch adds an increment to core_id, assuming thats how we are
supposed to cycle through the GPUs.

Tested on an IMX6Q6AVT10AD where it works with this patch applied.

Signed-off-by: David Oberhollenzer <david.oberhollenzer@sigma-star.at>